### PR TITLE
Add endpoint to get execution proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slot_clock",
+ "ssz_types",
  "state_processing",
  "store",
  "sysinfo",

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -39,6 +39,7 @@ sensitive_url = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slot_clock = { workspace = true }
+ssz_types = { workspace = true }
 state_processing = { workspace = true }
 store = { workspace = true }
 sysinfo = { workspace = true }

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -5,14 +5,17 @@ use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkip
 use eth2::beacon_response::{ExecutionOptimisticFinalizedMetadata, UnversionedResponse};
 use eth2::types::BlockId as CoreBlockId;
 use eth2::types::DataColumnIndicesQuery;
-use eth2::types::{BlobIndicesQuery, BlobWrapper, BlobsVersionedHashesQuery};
+use eth2::types::{
+    BlobIndicesQuery, BlobWrapper, BlobsVersionedHashesQuery, ExecutionProofIdsQuery,
+};
 use fixed_bytes::FixedBytesExtended;
+use ssz_types::RuntimeVariableList;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 use types::{
-    BlobSidecarList, DataColumnSidecarList, EthSpec, ForkName, Hash256, SignedBeaconBlock,
-    SignedBlindedBeaconBlock, Slot,
+    BlobSidecarList, DataColumnSidecarList, EthSpec, ExecutionProof, ExecutionProofId, ForkName,
+    Hash256, MAX_PROOFS, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot,
 };
 use warp::Rejection;
 
@@ -26,6 +29,12 @@ type Finalized = bool;
 type DataColumnsResponse<T> = (
     DataColumnSidecarList<<T as BeaconChainTypes>::EthSpec>,
     ForkName,
+    ExecutionOptimistic,
+    Finalized,
+);
+
+type ExecutionProofsResponse = (
+    RuntimeVariableList<Arc<ExecutionProof>>,
     ExecutionOptimistic,
     Finalized,
 );
@@ -310,6 +319,53 @@ impl BlockId {
             execution_optimistic,
             finalized,
         ))
+    }
+
+    pub fn get_execution_proofs<T: BeaconChainTypes>(
+        &self,
+        query: ExecutionProofIdsQuery,
+        chain: &BeaconChain<T>,
+    ) -> Result<ExecutionProofsResponse, Rejection> {
+        if !chain.spec.is_zkvm_enabled() {
+            return Err(warp_utils::reject::custom_bad_request(
+                "zkvm is not enabled for this node".to_string(),
+            ));
+        }
+
+        let (root, execution_optimistic, finalized) = self.root(chain)?;
+        let _block = BlockId::blinded_block_by_root(&root, chain)?.ok_or_else(|| {
+            warp_utils::reject::custom_not_found(format!("beacon block with root {}", root))
+        })?;
+
+        let mut proofs = chain
+            .store
+            .get_execution_proofs(&root)
+            .map_err(warp_utils::reject::unhandled_error)?;
+
+        if proofs.is_empty() {
+            return Err(warp_utils::reject::custom_not_found(format!(
+                "no execution proofs stored for block {root}"
+            )));
+        }
+
+        let proof_ids = query
+            .proof_ids
+            .map(|ids| {
+                ids.into_iter()
+                    .map(ExecutionProofId::new)
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()
+            .map_err(warp_utils::reject::custom_bad_request)?;
+
+        if let Some(proof_ids) = proof_ids {
+            proofs.retain(|proof| proof_ids.contains(&proof.proof_id));
+        }
+
+        let proof_list = RuntimeVariableList::new(proofs, MAX_PROOFS)
+            .map_err(|e| warp_utils::reject::custom_server_error(format!("{:?}", e)))?;
+
+        Ok((proof_list, execution_optimistic, finalized))
     }
 
     #[allow(clippy::type_complexity)]

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -210,6 +210,7 @@ pub fn prometheus_metrics() -> warp::filters::log::Log<impl Fn(warp::filters::lo
                 .or_else(|| starts_with("v2/beacon/blocks"))
                 .or_else(|| starts_with("v1/beacon/blob_sidecars"))
                 .or_else(|| starts_with("v1/beacon/blobs"))
+                .or_else(|| starts_with("v1/beacon/execution_proofs"))
                 .or_else(|| starts_with("v1/beacon/blocks/head/root"))
                 .or_else(|| starts_with("v1/beacon/blinded_blocks"))
                 .or_else(|| starts_with("v2/beacon/blinded_blocks"))
@@ -1386,6 +1387,53 @@ pub fn serve<T: BeaconChainTypes>(
                                 response.metadata.execution_optimistic.unwrap_or(false),
                                 response.metadata.finalized.unwrap_or(false),
                                 response.data,
+                            )?;
+                            Ok(warp::reply::json(&res).into_response())
+                        }
+                    }
+                })
+            },
+        );
+
+    // GET beacon/execution_proofs/{block_id}
+    let get_execution_proofs = eth_v1
+        .clone()
+        .and(warp::path("beacon"))
+        .and(warp::path("execution_proofs"))
+        .and(block_id_or_err)
+        .and(warp::path::end())
+        .and(multi_key_query::<api_types::ExecutionProofIdsQuery>())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .and(warp::header::optional::<api_types::Accept>("accept"))
+        .then(
+            |block_id: BlockId,
+             proof_ids_res: Result<api_types::ExecutionProofIdsQuery, warp::Rejection>,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>,
+             accept_header: Option<api_types::Accept>| {
+                task_spawner.blocking_response_task(Priority::P1, move || {
+                    let proof_ids = proof_ids_res?;
+                    let (proofs, execution_optimistic, finalized) =
+                        block_id.get_execution_proofs(proof_ids, &chain)?;
+
+                    match accept_header {
+                        Some(api_types::Accept::Ssz) => Response::builder()
+                            .status(200)
+                            .body(proofs.as_ssz_bytes().into())
+                            .map(|res: Response<Body>| add_ssz_content_type_header(res))
+                            .map_err(|e| {
+                                warp_utils::reject::custom_server_error(format!(
+                                    "failed to create response: {}",
+                                    e
+                                ))
+                            }),
+                        _ => {
+                            let res = execution_optimistic_finalized_beacon_response(
+                                ResponseIncludesVersion::No,
+                                execution_optimistic,
+                                finalized,
+                                &proofs,
                             )?;
                             Ok(warp::reply::json(&res).into_response())
                         }
@@ -3287,6 +3335,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_beacon_block_root)
                 .uor(get_blob_sidecars)
                 .uor(get_blobs)
+                .uor(get_execution_proofs)
                 .uor(get_beacon_pool_attestations)
                 .uor(get_beacon_pool_attester_slashings)
                 .uor(get_beacon_pool_proposer_slashings)

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -118,7 +118,9 @@ impl ApiTesterConfig {
     }
 
     fn with_zkvm(mut self) -> Self {
+        // TODO(zkproofs): shouldn't need both of these to be enabled
         self.enable_zkvm = true;
+        self.spec.zkvm_enabled = true;
         self
     }
 }
@@ -1962,6 +1964,60 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_get_execution_proofs(self, filter: bool) -> Self {
+        let head = self.chain.head_snapshot();
+        let block_root = head.beacon_block_root;
+
+        let proof_ids = [
+            ExecutionProofId::new(0).expect("Valid proof id"),
+            ExecutionProofId::new(1).expect("Valid proof id"),
+        ];
+        let proofs = proof_ids
+            .iter()
+            .map(|proof_id| self.create_test_execution_proof_with_id(*proof_id))
+            .collect::<Vec<_>>();
+
+        self.chain
+            .store
+            .put_execution_proofs(&block_root, &proofs)
+            .unwrap();
+
+        let filter_ids = filter.then(|| vec![proof_ids[1].as_u8()]);
+        let result = match self
+            .client
+            .get_execution_proofs(CoreBlockId::Root(block_root), filter_ids.as_deref())
+            .await
+        {
+            Ok(result) => result.unwrap().into_data(),
+            Err(e) => panic!("query failed incorrectly: {e:?}"),
+        };
+
+        if filter {
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].proof_id, proof_ids[1]);
+        } else {
+            assert_eq!(result.len(), proofs.len());
+        }
+
+        self
+    }
+
+    pub async fn test_get_execution_proofs_zkvm_disabled(self) -> Self {
+        let block_id = BlockId(CoreBlockId::Head);
+        let (block_root, _, _) = block_id.root(&self.chain).unwrap();
+        let result = self
+            .client
+            .get_execution_proofs(CoreBlockId::Root(block_root), None)
+            .await;
+
+        match result {
+            Ok(response) => panic!("query should fail: {response:?}"),
+            Err(e) => assert_eq!(e.status().unwrap(), 400),
+        }
+
+        self
+    }
+
     pub async fn test_get_blobs_post_fulu_full_node(self, versioned_hashes: bool) -> Self {
         let block_id = BlockId(CoreBlockId::Head);
         let (block_root, _, _) = block_id.root(&self.chain).unwrap();
@@ -2752,6 +2808,11 @@ impl ApiTester {
 
     /// Helper to create a test execution proof for the head block
     fn create_test_execution_proof(&self) -> ExecutionProof {
+        let proof_id = ExecutionProofId::new(0).expect("Valid proof id");
+        self.create_test_execution_proof_with_id(proof_id)
+    }
+
+    fn create_test_execution_proof_with_id(&self, proof_id: ExecutionProofId) -> ExecutionProof {
         let head = self.chain.head_snapshot();
         let block_root = head.beacon_block_root;
         let slot = head.beacon_block.slot();
@@ -2763,7 +2824,6 @@ impl ApiTester {
             .map(|p| p.block_hash())
             .unwrap_or_else(|_| ExecutionBlockHash::zero());
 
-        let proof_id = ExecutionProofId::new(0).expect("Valid proof id");
         let proof_data = vec![0u8; 32]; // Dummy proof data
 
         ExecutionProof::new(proof_id, slot, block_hash, block_root, proof_data)
@@ -8165,6 +8225,24 @@ async fn get_blob_sidecars_pre_deneb() {
     ApiTester::new_from_config(config)
         .await
         .test_get_blob_sidecars_pre_deneb()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_execution_proofs() {
+    ApiTester::new_with_zkvm()
+        .await
+        .test_get_execution_proofs(false)
+        .await
+        .test_get_execution_proofs(true)
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_execution_proofs_zkvm_disabled() {
+    ApiTester::new()
+        .await
+        .test_get_execution_proofs_zkvm_disabled()
         .await;
 }
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1297,6 +1297,17 @@ impl BeaconNodeHttpClient {
         Ok(path)
     }
 
+    /// Path for `v1/beacon/execution_proofs/{block_id}`
+    pub fn get_execution_proofs_path(&self, block_id: BlockId) -> Result<Url, Error> {
+        let mut path = self.eth_path(V1)?;
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("execution_proofs")
+            .push(&block_id.to_string());
+        Ok(path)
+    }
+
     /// Path for `v1/beacon/blinded_blocks/{block_id}`
     pub fn get_beacon_blinded_blocks_path(&self, block_id: BlockId) -> Result<Url, Error> {
         let mut path = self.eth_path(V1)?;
@@ -1369,6 +1380,30 @@ impl BeaconNodeHttpClient {
                 .join(",");
             path.query_pairs_mut()
                 .append_pair("versioned_hashes", &hashes_string);
+        }
+
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::Unversioned))
+    }
+
+    /// `GET v1/beacon/execution_proofs/{block_id}`
+    ///
+    /// Returns `Ok(None)` on a 404 error.
+    pub async fn get_execution_proofs(
+        &self,
+        block_id: BlockId,
+        proof_ids: Option<&[u8]>,
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<Vec<ExecutionProof>>>, Error>
+    {
+        let mut path = self.get_execution_proofs_path(block_id)?;
+        if let Some(proof_ids) = proof_ids {
+            let ids_string = proof_ids
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            path.query_pairs_mut().append_pair("proof_ids", &ids_string);
         }
 
         self.get_opt(path)

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -690,6 +690,13 @@ pub struct BlobIndicesQuery {
 
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct ExecutionProofIdsQuery {
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub proof_ids: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlobsVersionedHashesQuery {
     #[serde(default, deserialize_with = "option_query_vec")]
     pub versioned_hashes: Option<Vec<Hash256>>,


### PR DESCRIPTION
## Issue Addressed

Essentially ` GET /eth/v1/beacon/execution_proofs/{block_id}?proof_ids=`

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
