### PR TITLE
fix: allow --builder without --execution-endpoint

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -912,7 +912,6 @@ pub fn cli_app() -> Command {
                 .alias("payload-builder")
                 .alias("payload-builders")
                 .help("The URL of a service compatible with the MEV-boost API.")
-                .requires("execution-endpoint")
                 .action(ArgAction::Set)
                 .display_order(0)
         )


### PR DESCRIPTION
## Issue Addressed

Running lighthouse with `--proof-engine-endpoint` (EIP-8025, no EL) and `--builder` (MEV-boost) fails because `--builder` has `.requires("execution-endpoint")` in its clap definition.

This breaks the kurtosis devnet config where a participant has `el_type: None` but still needs MEV-boost for block building via zkboost proofs.

## Proposed Changes

Remove the `.requires("execution-endpoint")` constraint from `--builder`. Since `--proof-engine-endpoint` serves as an alternative execution path, `--builder` should be usable with either `--execution-endpoint` or `--proof-engine-endpoint`.

## Additional Info

Error when running with `el_type: None` + MEV enabled:
```
error: the following required arguments were not provided:
  --execution-endpoint <EXECUTION-ENDPOINT>

Usage: lighthouse beacon_node --metrics --telemetry-collector-url <URL> --proof-engine-endpoint <PROOF-ENGINE-ENDPOINT> --execution-endpoint <EXECUTION-ENDPOINT> ...
```