### PR TITLE
ci(nightly-tests): set CC/CXX to clang to match test-suite

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -21,6 +21,14 @@ env:
   CARGO_INCREMENTAL: 0
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
   TEST_FEATURES: portable
+  # Must match test-suite.yml so both workflows populate the shared
+  # moonrepo/setup-rust cache with leveldb-sys artifacts built against the
+  # same toolchain. Mismatches force cmake to rebuild leveldb-sys on restore,
+  # which re-runs its install step and tries to write /usr/local/lib
+  # (permission denied).
+  CC: clang
+  CXX: clang++
+  CXXFLAGS: "-include ctime"
 
 jobs:
   setup-matrix:


### PR DESCRIPTION
## Issue Addressed

PR #33's CI failed with every test-suite job dying on `leveldb-sys`:

```
You have changed variables that require your cache to be deleted.
  CMAKE_C_COMPILER= /usr/bin/clang
  CMAKE_CXX_COMPILER= /usr/bin/clang++
...
file INSTALL cannot copy file ".../libleveldb.a" to "/usr/local/lib/libleveldb.a": Permission denied.
```

## Root Cause

`test-suite.yml` sets `CC: clang` / `CXX: clang++` in its top-level env. `nightly-tests.yml` does not — so the scheduled nightly run builds `leveldb-sys` with the runner's default `gcc/g++` and populates the shared `moonrepo/setup-rust` cache (key prefix `setup-rustcargo-v1-linux-*`, shared across workflows on the same branch).

When a PR triggers `test-suite` and restores that cache, cmake sees the compiler mismatch, invalidates its own build subdir, and re-runs `cmake --build --target install` which tries to write `/usr/local/lib/libleveldb.a` without sudo — permission denied — taking out every downstream job in the matrix.

## Proposed Changes

Mirror `test-suite.yml`'s `CC` / `CXX` / `CXXFLAGS` in `nightly-tests.yml` so both workflows populate the shared cache with compatible toolchain artifacts.

## Additional Info

Existing poisoned caches need to be cleared once (via UI or `gh cache delete`) for this fix to take effect on the first run; I've already cleared them.