### PR TITLE
ci(nightly-tests): drop http-api-tests job

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -65,28 +65,6 @@ jobs:
       run: make test-beacon-chain-${{ matrix.fork }}
       timeout-minutes: 60
 
-  http-api-tests:
-    name: http-api-tests
-    needs: setup-matrix
-    runs-on: 'ubuntu-latest'
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    strategy:
-      matrix:
-        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
-      uses: moonrepo/setup-rust@v1
-      with:
-          channel: stable
-          cache-target: release
-          bins: cargo-nextest
-    - name: Run http_api tests for ${{ matrix.fork }}
-      run: make test-http-api-${{ matrix.fork }}
-      timeout-minutes: 60
-
   op-pool-tests:
     name: op-pool-tests
     needs: setup-matrix


### PR DESCRIPTION
## Summary

- The `nightly-tests` workflow has been red every night because all 4 pre-deneb `http-api-tests` matrix jobs (phase0, altair, bellatrix, capella) panic at `beacon_node/beacon_chain/src/test_utils.rs:965` with `Should always be a blinded payload response`. `make_blinded_block_with_modifier` unconditionally demands a blinded payload response that the mock-builder path can't produce on earlier forks.
- Upstream hit the exact same failure and resolved it by removing the `http-api-tests` job from the nightly workflow: sigp/lighthouse#8646 ("`http-api` tests are failing for earlier forks... we might be able to just remove them for earlier forks in the nightly tests as they're no longer relevant"). This PR mirrors that change — deletion only, no other workflow modifications.
- `beacon-chain-tests`, `op-pool-tests`, and `network-tests` already pass across every prior fork and continue to run, so the nightly sweep still earns its keep.

## Test plan

- [ ] `gh workflow run nightly-tests.yml --ref fix/nightly-tests` and confirm the remaining matrix is all green.
- [ ] After merge, watch the next scheduled run (08:30 UTC) end-to-end.

Latest failing run for reference: https://github.com/eth-act/lighthouse/actions/runs/24713873805

🤖 Generated with [Claude Code](https://claude.com/claude-code)