### PR TITLE
Update execution proofs beacon-APIs

### DIFF
--- a/beacon_node/http_api/src/eip8025.rs
+++ b/beacon_node/http_api/src/eip8025.rs
@@ -1,7 +1,7 @@
 //! EIP-8025: Optional Execution Proofs - HTTP API Endpoints
 //!
 //! This module provides HTTP API endpoints for:
-//! - GET `/eth/v1/beacon/proofs/execution_proofs/{block_id}` - Retrieve execution proofs for a block
+//! - GET `/eth/v1/beacon/execution_proofs/{block_id}` - Retrieve execution proofs for a block
 //! - POST `/eth/v1/beacon/execution_proofs` - Submit pre-signed execution proofs
 
 use crate::block_id::BlockId;
@@ -16,9 +16,9 @@ use types::{ProofStatus, SignedExecutionProof};
 use warp::Reply;
 use warp::http::Response;
 use warp::hyper::Body;
-use warp_utils::reject::{custom_bad_request, custom_server_error};
+use warp_utils::reject::{custom_bad_request, custom_not_implemented, custom_server_error};
 
-/// Response for GET /eth/v1/beacon/proofs/execution_proofs/{block_id}
+/// Response for GET /eth/v1/beacon/execution_proofs/{block_id}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecutionProofsResponse {
     pub execution_optimistic: bool,
@@ -48,7 +48,7 @@ pub fn get_execution_proofs<T: BeaconChainTypes>(
         .ok_or_else(|| custom_server_error("Execution layer not available".to_string()))?;
 
     let proof_engine = execution_layer.proof_engine().ok_or_else(|| {
-        custom_bad_request(
+        custom_not_implemented(
             "Proof engine not configured. Start with --proof-engine-endpoint to enable EIP-8025."
                 .to_string(),
         )
@@ -97,7 +97,7 @@ pub async fn submit_execution_proofs<T: BeaconChainTypes>(
         .and_then(|el| el.proof_engine())
         .is_none()
     {
-        return Err(custom_bad_request(
+        return Err(custom_not_implemented(
             "Proof engine not configured. Start with --proof-engine-endpoint to enable EIP-8025."
                 .to_string(),
         ));

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -72,7 +72,7 @@ pub use publish_blocks::{
 };
 use serde::{Deserialize, Serialize};
 use slot_clock::SlotClock;
-use ssz::Encode;
+use ssz::{Decode, Encode};
 pub use state_id::StateId;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -91,7 +91,7 @@ use tokio_stream::{
 use tracing::{debug, info, warn};
 use types::{
     BeaconStateError, Checkpoint, ConfigAndPreset, Epoch, EthSpec, ForkName, Hash256,
-    SignedBlindedBeaconBlock, Slot,
+    SignedBlindedBeaconBlock, Slot, execution::ExecutionProofList,
 };
 use version::{
     ResponseIncludesVersion, V1, V2, add_consensus_version_header, add_ssz_content_type_header,
@@ -1817,18 +1817,42 @@ pub fn serve<T: BeaconChainTypes>(
         .clone()
         .and(block_id_or_err)
         .and(warp::path::end())
+        .and(warp::header::optional::<api_types::Accept>("accept"))
         .then(
             |task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
-             block_id: BlockId| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
-                    eip8025::get_execution_proofs(block_id, chain)
+             block_id: BlockId,
+             accept_header: Option<api_types::Accept>| {
+                task_spawner.blocking_response_task(Priority::P1, move || {
+                    let response = eip8025::get_execution_proofs(block_id, chain)?;
+
+                    match accept_header {
+                        Some(api_types::Accept::Ssz) => {
+                            let proofs =
+                                ExecutionProofList::try_from(response.data).map_err(|e| {
+                                    warp_utils::reject::custom_server_error(format!(
+                                        "failed to create response: {e:?}"
+                                    ))
+                                })?;
+                            Response::builder()
+                                .status(200)
+                                .body(proofs.as_ssz_bytes().into())
+                                .map(|res: Response<Body>| add_ssz_content_type_header(res))
+                                .map_err(|e| {
+                                    warp_utils::reject::custom_server_error(format!(
+                                        "failed to create response: {}",
+                                        e
+                                    ))
+                                })
+                        }
+                        _ => Ok(warp::reply::json(&response).into_response()),
+                    }
                 })
             },
         );
 
     // POST beacon/execution_proofs
-    let post_prover_execution_proofs = beacon_proofs_path
+    let post_execution_proofs = beacon_proofs_path
         .clone()
         .and(warp::path::end())
         .and(warp_utils::json::json())
@@ -1843,6 +1867,35 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.spawn_async_with_rejection(Priority::P1, async move {
                     eip8025::submit_execution_proofs(proofs, chain, network_globals, network_send)
                         .await
+                })
+            },
+        );
+
+    let post_execution_proofs_ssz = beacon_proofs_path
+        .clone()
+        .and(warp::path::end())
+        .and(warp::body::bytes())
+        .and(network_globals.clone())
+        .and(network_tx_filter.clone())
+        .then(
+            |task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>,
+             proof_bytes: Bytes,
+             network_globals: Arc<NetworkGlobals<T::EthSpec>>,
+             network_send: UnboundedSender<NetworkMessage<T::EthSpec>>| {
+                task_spawner.spawn_async_with_rejection(Priority::P1, async move {
+                    let proofs = ExecutionProofList::from_ssz_bytes(&proof_bytes).map_err(|e| {
+                        warp_utils::reject::custom_bad_request(format!("invalid SSZ: {e:?}"))
+                    })?;
+                    eip8025::submit_execution_proofs(
+                        eip8025::SubmitExecutionProofsRequest {
+                            proofs: Vec::from(proofs),
+                        },
+                        chain,
+                        network_globals,
+                        network_send,
+                    )
+                    .await
                 })
             },
         );
@@ -3406,7 +3459,8 @@ pub fn serve<T: BeaconChainTypes>(
                         post_beacon_blocks_ssz
                             .uor(post_beacon_blocks_v2_ssz)
                             .uor(post_beacon_blinded_blocks_ssz)
-                            .uor(post_beacon_blinded_blocks_v2_ssz),
+                            .uor(post_beacon_blinded_blocks_v2_ssz)
+                            .uor(post_execution_proofs_ssz),
                     )
                     .uor(post_beacon_blocks)
                     .uor(post_beacon_blinded_blocks)
@@ -3442,7 +3496,7 @@ pub fn serve<T: BeaconChainTypes>(
                     .uor(post_lighthouse_add_peer)
                     .uor(post_lighthouse_remove_peer)
                     .uor(post_lighthouse_custody_backfill)
-                    .uor(post_prover_execution_proofs)
+                    .uor(post_execution_proofs)
                     .recover(warp_utils::reject::handle_rejection),
             ),
         )

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -17,7 +17,7 @@ use tokio_util::{
     compat::{Compat, FuturesAsyncReadCompatExt},
 };
 use typenum::Unsigned;
-use types::execution::eip8025::MaxExecutionProofsPerPayload;
+use types::execution::eip8025::{MaxExecutionProofsPerPayload, MaxProofSize};
 use types::{
     BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BlobSidecar, ChainSpec, DataColumnSidecar,
     EmptyBlock, Epoch, EthSpec, EthSpecId, ForkContext, ForkName, LightClientBootstrap,
@@ -127,11 +127,11 @@ pub static LIGHT_CLIENT_UPDATES_BY_RANGE_ELECTRA_MAX: LazyLock<usize> =
 /// - ExecutionProof fixed header (proof_data offset + proof_type + public_input): 4 + 1 + 32 = 37
 pub const SIGNED_EXECUTION_PROOF_MIN_SIZE: usize = 4 + 8 + 96 + 37;
 
-/// Maximum SSZ size of a `SignedExecutionProof` (MaxProofSize = 409600 bytes):
+/// Maximum SSZ size of a `SignedExecutionProof` (MaxProofSize = 1,376,256 bytes):
 /// - SignedExecutionProof fixed header: 4 + 8 + 96 = 108 bytes
 /// - ExecutionProof fixed header: 4 + 1 + 32 = 37 bytes
-/// - proof_data: MaxProofSize = 100 * 4096 = 409600 bytes
-pub const SIGNED_EXECUTION_PROOF_MAX_SIZE: usize = 4 + 8 + 96 + 37 + 409600;
+/// - proof_data: MaxProofSize = 1344 * 1024 = 1,376,256 bytes
+pub const SIGNED_EXECUTION_PROOF_MAX_SIZE: usize = 4 + 8 + 96 + 37 + MaxProofSize::USIZE;
 
 /// The protocol prefix the RPC protocol id.
 const PROTOCOL_PREFIX: &str = "/eth2/beacon_chain/req";
@@ -1140,5 +1140,19 @@ impl RPCError {
             RPCError::ErrorResponse(code, ..) => code.into(),
             e => e.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_execution_proof_max_size_includes_max_proof_size() {
+        assert_eq!(MaxProofSize::USIZE, 1_376_256);
+        assert_eq!(
+            SIGNED_EXECUTION_PROOF_MAX_SIZE,
+            SIGNED_EXECUTION_PROOF_MIN_SIZE + 1_376_256
+        );
     }
 }

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -66,6 +66,15 @@ pub fn custom_bad_request(msg: String) -> warp::reject::Rejection {
 }
 
 #[derive(Debug)]
+pub struct CustomNotImplemented(pub String);
+
+impl Reject for CustomNotImplemented {}
+
+pub fn custom_not_implemented(msg: String) -> warp::reject::Rejection {
+    warp::reject::custom(CustomNotImplemented(msg))
+}
+
+#[derive(Debug)]
 pub struct CustomDeserializeError(pub String);
 
 impl Reject for CustomDeserializeError {}
@@ -183,6 +192,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if let Some(e) = err.find::<crate::reject::CustomBadRequest>() {
         code = StatusCode::BAD_REQUEST;
         message = format!("BAD_REQUEST: {}", e.0);
+    } else if let Some(e) = err.find::<crate::reject::CustomNotImplemented>() {
+        code = StatusCode::NOT_IMPLEMENTED;
+        message = format!("NOT_IMPLEMENTED: {}", e.0);
     } else if let Some(e) = err.find::<crate::reject::CustomServerError>() {
         code = StatusCode::INTERNAL_SERVER_ERROR;
         message = format!("INTERNAL_SERVER_ERROR: {}", e.0);
@@ -241,5 +253,31 @@ pub async fn convert_rejection<T: Reply>(res: Result<T, warp::Rejection>) -> Res
             let Ok(reply) = handle_rejection(e).await;
             reply.into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eth2::types::ErrorMessage;
+    use warp::Reply;
+    use warp::hyper::body;
+
+    #[tokio::test]
+    async fn custom_not_implemented_maps_to_501() {
+        let message =
+            "Proof engine not configured. Start with --proof-engine-endpoint to enable EIP-8025.";
+
+        let reply = handle_rejection(custom_not_implemented(message.to_string()))
+            .await
+            .unwrap()
+            .into_response();
+
+        assert_eq!(reply.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let body = body::to_bytes(reply.into_body()).await.unwrap();
+        let error: ErrorMessage = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error.code, StatusCode::NOT_IMPLEMENTED.as_u16());
+        assert_eq!(error.message, format!("NOT_IMPLEMENTED: {message}"));
     }
 }

--- a/consensus/types/src/execution/eip8025.rs
+++ b/consensus/types/src/execution/eip8025.rs
@@ -13,14 +13,17 @@ use tree_hash_derive::TreeHash;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-/// Maximum proof size: 400 KiB (409600 bytes)
+/// Maximum proof size: 1344 KiB (1,376,256 bytes).
 ///
-/// Product of U100 * U4096
-pub type MaxProofSize = typenum::Prod<typenum::U100, typenum::U4096>;
+/// Product of (U21 * U64) * U1024.
+pub type MaxProofSize = typenum::Prod<MaxProofSizeKiB, typenum::U1024>;
+
+/// Maximum proof size in KiB.
+pub type MaxProofSizeKiB = typenum::Prod<typenum::U21, typenum::U64>;
 
 /// Proof data type
 ///
-/// VariableList of bytes with max length [`MaxProofSize`]`
+/// VariableList of bytes with max length [`MaxProofSize`].
 pub type ProofData = VariableList<u8, MaxProofSize>;
 
 /// Maximum execution proofs per payload
@@ -339,5 +342,13 @@ mod tests {
             proof_types: vec![1, 2, 3],
         };
         assert_eq!(attrs_with_types.proof_types.len(), 3);
+    }
+
+    #[test]
+    fn max_proof_size_is_1344_kib() {
+        use typenum::Unsigned;
+
+        assert_eq!(MaxProofSizeKiB::USIZE, 1344);
+        assert_eq!(MaxProofSize::USIZE, 1_376_256);
     }
 }


### PR DESCRIPTION
## Summary

- return `501 Not Implemented` when EIP-8025 proof engine support is not configured
- support application/octet-stream SSZ request/response handling for EIP-8025 execution proof endpoints
- bump EIP-8025 `MAX_PROOF_SIZE` to `1,376,256` bytes (`1344 KiB`) and derive the RPC signed-proof max from the type-level bound
